### PR TITLE
feat/1.0.2

### DIFF
--- a/LotComAPI/Controllers/PrintController.cs
+++ b/LotComAPI/Controllers/PrintController.cs
@@ -54,7 +54,7 @@ public class PrintController : ControllerBase
     /// <param name="date"></param>
     /// <returns></returns>
     [HttpGet("onDate")]
-    public ActionResult<IEnumerable<PrintEntity>> GetOnDate([FromQuery] string day, [FromQuery] string month, [FromQuery] string year)
+    public ActionResult<IEnumerable<PrintDto>> GetOnDate([FromQuery] string day, [FromQuery] string month, [FromQuery] string year)
     {
         // parse the date to a DateTime object
         string Date = $"{month}/{day}/{year}";
@@ -76,7 +76,7 @@ public class PrintController : ControllerBase
     /// <param name="date"></param>
     /// <returns></returns>
     [HttpGet("onDateBy")]
-    public ActionResult<IEnumerable<PrintEntity>> GetOnDateByProcess([FromQuery] string day, [FromQuery] string month, [FromQuery] string year, [FromQuery] int processId)
+    public ActionResult<IEnumerable<PrintDto>> GetOnDateByProcess([FromQuery] string day, [FromQuery] string month, [FromQuery] string year, [FromQuery] int processId)
     {
         // parse the date to a DateTime object
         string Date = $"{month}/{day}/{year}";
@@ -87,6 +87,24 @@ public class PrintController : ControllerBase
         }
         IEnumerable<PrintEntity> PrintsFromDatabase = _printService.GetOnDateByProcess(ParsedDate, processId);
         // convert each of the PrintEntity entities into a Dto
+        IEnumerable<PrintDto> Dtos = PrintsFromDatabase
+            .Select(_printMapper.EntityToDto);
+        return Ok(Dtos);
+    }
+
+    /// <summary>
+    /// Processes a GET HTTP request for all Print entities that include serialNumber in the database.
+    /// </summary>
+    /// <param name="serialNumber"></param>
+    /// <returns></returns>
+    [HttpGet("serialNumber")]
+    public ActionResult<IEnumerable<PrintDto>> GetWithSerialNumber([FromQuery] int serialNumber)
+    {
+        IEnumerable<PrintEntity>? PrintsFromDatabase = _printService.GetWithSerialNumber(serialNumber);
+        if (PrintsFromDatabase is null)
+        {
+            return NotFound();
+        }
         IEnumerable<PrintDto> Dtos = PrintsFromDatabase
             .Select(_printMapper.EntityToDto);
         return Ok(Dtos);

--- a/LotComAPI/Controllers/ScanController.cs
+++ b/LotComAPI/Controllers/ScanController.cs
@@ -67,7 +67,7 @@ public class ScanController : ControllerBase
     }
 
     /// <summary>
-    /// Processes a GET HTTP request for a single Print object in the database.
+    /// Processes a GET HTTP request for a single Scan object in the database.
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
@@ -80,6 +80,24 @@ public class ScanController : ControllerBase
             return NotFound();
         }
         return Ok(_scanMapper.EntityToDto(ScanFromDatabase));
+    }
+
+    /// <summary>
+    /// Processes a GET HTTP request for all Scan entities that include serialNumber in the database.
+    /// </summary>
+    /// <param name="serialNumber"></param>
+    /// <returns></returns>
+    [HttpGet("serialNumber")]
+    public ActionResult<IEnumerable<ScanDto>> GetWithSerialNumber([FromQuery] int serialNumber)
+    {
+        IEnumerable<ScanEntity>? ScansFromDatabase = _scanService.GetWithSerialNumber(serialNumber);
+        if (ScansFromDatabase is null)
+        {
+            return NotFound();
+        }
+        IEnumerable<ScanDto> Dtos = ScansFromDatabase
+            .Select(_scanMapper.EntityToDto);
+        return Ok(Dtos);
     }
 
     /// <summary>

--- a/LotComAPI/Services/IPrintService.cs
+++ b/LotComAPI/Services/IPrintService.cs
@@ -7,6 +7,7 @@ public interface IPrintService
     IEnumerable<PrintEntity> GetAll();
     IEnumerable<PrintEntity> GetOnDate(DateTime Date);
     IEnumerable<PrintEntity> GetOnDateByProcess(DateTime Date, int ProcessId);
+    IEnumerable<PrintEntity>? GetWithSerialNumber(int serialNumber);
     PrintEntity? Get(int id);
     PrintEntity Create(PrintEntity Print);
     bool Update(int id, PrintEntity Print);

--- a/LotComAPI/Services/IScanService.cs
+++ b/LotComAPI/Services/IScanService.cs
@@ -7,6 +7,7 @@ public interface IScanService
     IEnumerable<ScanEntity> GetAll();
     ScanEntity? Get(int id);
     IEnumerable<ScanEntity>? GetAllWithinRange(int days);
+    IEnumerable<ScanEntity>? GetWithSerialNumber(int serialNumber);
     ScanEntity Create(ScanEntity Entity);
     bool Update(int id, ScanEntity Entity);
     void Delete(ScanEntity Entity);

--- a/LotComAPI/Services/PrintService.cs
+++ b/LotComAPI/Services/PrintService.cs
@@ -79,6 +79,25 @@ public class PrintService : IPrintService
     }
 
     /// <summary>
+    /// Queries all of the existing Prints that contain a Serial Number that matches serialNumber from the Print database.
+    /// </summary>
+    /// <param name="serialNumber"></param>
+    /// <returns></returns>
+    public IEnumerable<PrintEntity>? GetWithSerialNumber(int serialNumber)
+    {
+        // confirm that a valid serial number was passed
+        if (serialNumber < 1)
+        {
+            return null;
+        }
+        return _printContext.Prints
+            .AsEnumerable()
+            .Where(x => x.GetSerialNumber()
+            .Equals(serialNumber)
+        );
+    }
+
+    /// <summary>
     /// Queries a specific Print from the Database by id.
     /// </summary>
     /// <param name="id"></param>

--- a/LotComAPI/Services/ScanService.cs
+++ b/LotComAPI/Services/ScanService.cs
@@ -90,6 +90,25 @@ public class ScanService : IScanService
     }
 
     /// <summary>
+    /// Queries all of the existing Scans that contain a Serial Number that matches serialNumber from the Scan database.
+    /// </summary>
+    /// <param name="serialNumber"></param>
+    /// <returns></returns>
+    public IEnumerable<ScanEntity>? GetWithSerialNumber(int serialNumber)
+    {
+        // confirm that a valid serial number was passed
+        if (serialNumber < 1)
+        {
+            return null;
+        }
+        return _scanContext.Scans
+            .AsEnumerable()
+            .Where(x => x.GetSerialNumber()
+            .Equals(serialNumber)
+        );
+    }
+
+    /// <summary>
     /// Creates a new Scan in the Database.
     /// </summary>
     /// <param name="Entity"></param>


### PR DESCRIPTION
# feat/1.0.2

## Addressed Feature Request
Resolves #16 

## Summary

**Briefly describe the feature being introduced.**

API endpoints to retrieve all Scans or Prints with a specific Serial Number have been implemented.

## Rationale

**Explain the reasoning behind this feature and its benefits to the project.**

The ability to query for specific Serial Numbers in `Print` and `Scan` tables helps improve the **LotCom** backend server performance. Previously, services had to load all of the entities into runtime as `C#` objects to perform serial number based comparisons. This was causing `502 Bad Gateway` errors consistently, due to resource exhaustion.

## Changes

**List the major changes made in this pull request.**

#### `Service Layer`:
- Add `GetWithSerialNumber()` method:
  - Filters the `DbContext` layer into `Prints` or `Scans` that contain a specific value as their Serial Number.

#### `Controller Layer`:
- Add `GetWithSerialNumber()` method:
  - Retrieves all `Prints` or `Scans` that contain a specific value as their Serial Number.

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

This PR implements new functionality.

## Checklist

- [X] Code follows the project's coding standards

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**